### PR TITLE
refactor: fully dynamic conv layers

### DIFF
--- a/examples/conv2d_mnist/main.rs
+++ b/examples/conv2d_mnist/main.rs
@@ -163,18 +163,18 @@ where
         );
 
         let l0q: EltwiseConfig<F, BITS, DivideBy<F, 32>> =
-            EltwiseConfig::configure(cs, advices.get_slice(&[0..LEN], &[1, LEN]), None);
+            EltwiseConfig::configure(cs, advices.get_slice(&[0..LEN], &[LEN]), None);
         let l1: EltwiseConfig<F, BITS, ReLu<F>> =
-            EltwiseConfig::configure(cs, advices.get_slice(&[0..LEN], &[1, LEN]), None);
+            EltwiseConfig::configure(cs, advices.get_slice(&[0..LEN], &[LEN]), None);
 
         let l2: Affine1dConfig<F> = Affine1dConfig::configure(
             cs,
             &[
                 advices.get_slice(&[0..CLASSES], &[CLASSES, LEN]),
-                advices.get_slice(&[LEN + 2..LEN + 3], &[1, CLASSES]),
+                advices.get_slice(&[LEN + 2..LEN + 3], &[CLASSES]),
             ],
-            advices.get_slice(&[LEN..LEN + 1], &[1, LEN]),
-            advices.get_slice(&[CLASSES + 1..CLASSES + 2], &[1, CLASSES]),
+            advices.get_slice(&[LEN..LEN + 1], &[LEN]),
+            advices.get_slice(&[CLASSES + 1..CLASSES + 2], &[CLASSES]),
         );
         let public_output: Column<Instance> = cs.instance_column();
         cs.enable_equality(public_output);
@@ -201,7 +201,7 @@ where
         );
         let l0qout = config.l0q.layout(&mut layouter, l0out);
         let mut l1out = config.l1.layout(&mut layouter, l0qout);
-        l1out.reshape(&[1, LEN]);
+        l1out.flatten();
         let l2out = config.l2.layout(
             &mut layouter,
             l1out,
@@ -294,14 +294,14 @@ pub fn runconv() {
 
     kernels.reshape(&[OUT_CHANNELS, IN_CHANNELS, KERNEL_WIDTH, KERNEL_HEIGHT]);
 
-    let mut l2biases = Tensor::<i32>::from(myparams.biases.into_iter().map(|fl| {
+    let l2biases = Tensor::<i32>::from(myparams.biases.into_iter().map(|fl| {
         let dx = fl * (32 as f32);
         let rounded = dx.round();
         let integral: i32 = unsafe { rounded.to_int_unchecked() };
         integral
     }));
 
-    l2biases.reshape(&[1, CLASSES]);
+    // l2biases.reshape(&[1, CLASSES]);
 
     let mut l2weights = Tensor::<i32>::from(myparams.weights.into_iter().flatten().map(|fl| {
         let dx = fl * (32 as f32);

--- a/examples/mlp_4d.rs
+++ b/examples/mlp_4d.rs
@@ -61,29 +61,29 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
         })));
 
         let kernel = advices.get_slice(&[0..LEN], &[LEN, LEN]);
-        let bias = advices.get_slice(&[LEN + 2..LEN + 3], &[1, LEN]);
+        let bias = advices.get_slice(&[LEN + 2..LEN + 3], &[LEN]);
 
         let l0 = Affine1dConfig::<F>::configure(
             cs,
             &[kernel.clone(), bias.clone()],
-            advices.get_slice(&[LEN..LEN + 1], &[1, LEN]),
-            advices.get_slice(&[LEN + 1..LEN + 2], &[1, LEN]),
+            advices.get_slice(&[LEN..LEN + 1], &[LEN]),
+            advices.get_slice(&[LEN + 1..LEN + 2], &[LEN]),
         );
 
         let l2 = Affine1dConfig::<F>::configure(
             cs,
             &[kernel, bias],
-            advices.get_slice(&[LEN..LEN + 1], &[1, LEN]),
-            advices.get_slice(&[LEN + 1..LEN + 2], &[1, LEN]),
+            advices.get_slice(&[LEN..LEN + 1], &[LEN]),
+            advices.get_slice(&[LEN + 1..LEN + 2], &[LEN]),
         );
 
         // sets up a new ReLU table and resuses it for l1 and l3 non linearities
         let [l1, l3]: [EltwiseConfig<F, BITS, ReLu<F>>; 2] =
-            EltwiseConfig::configure_multiple(cs, advices.get_slice(&[0..LEN], &[1, LEN]));
+            EltwiseConfig::configure_multiple(cs, advices.get_slice(&[0..LEN], &[LEN]));
 
         // sets up a new Divide by table
         let l4: EltwiseConfig<F, BITS, DivideBy<F, 128>> =
-            EltwiseConfig::configure(cs, advices.get_slice(&[0..LEN], &[1, LEN]), None);
+            EltwiseConfig::configure(cs, advices.get_slice(&[0..LEN], &[LEN]), None);
 
         let public_output: Column<Instance> = cs.instance_column();
         cs.enable_equality(public_output);
@@ -145,7 +145,7 @@ pub fn runmlp() {
         &[4, 4],
     )
     .unwrap();
-    let l0_bias = Tensor::<i32>::new(Some(&[0, 0, 0, 1]), &[1, 4]).unwrap();
+    let l0_bias = Tensor::<i32>::new(Some(&[0, 0, 0, 1]), &[4]).unwrap();
 
     let l2_kernel = Tensor::<i32>::new(
         Some(&[0, 3, 10, -1, 0, 10, 1, 0, 0, 1, 0, 12, 1, -2, 32, 0]),
@@ -153,8 +153,8 @@ pub fn runmlp() {
     )
     .unwrap();
     // input data, with 1 padding to allow for bias
-    let input = Tensor::<i32>::new(Some(&[-30, -21, 11, 40]), &[1, 4]).unwrap();
-    let l2_bias = Tensor::<i32>::new(Some(&[0, 0, 0, 1]), &[1, 4]).unwrap();
+    let input = Tensor::<i32>::new(Some(&[-30, -21, 11, 40]), &[4]).unwrap();
+    let l2_bias = Tensor::<i32>::new(Some(&[0, 0, 0, 1]), &[4]).unwrap();
 
     let circuit = MyCircuit::<F, 4, 14> {
         input,

--- a/examples/smallonnx.rs
+++ b/examples/smallonnx.rs
@@ -51,20 +51,17 @@ mod onnx_example {
             })));
 
             let kernel = advices.get_slice(&[0..out_dims], &[out_dims, in_dims]);
-            let bias = advices.get_slice(&[out_dims + 2..out_dims + 3], &[1, out_dims]);
+            let bias = advices.get_slice(&[out_dims + 2..out_dims + 3], &[out_dims]);
 
             let l0 = Affine1dConfig::<F>::configure(
                 cs,
                 &[kernel, bias],
-                advices.get_slice(&[out_dims..out_dims + 1], &[1, in_dims]),
-                advices.get_slice(&[out_dims + 1..out_dims + 2], &[1, out_dims]),
+                advices.get_slice(&[out_dims..out_dims + 1], &[in_dims]),
+                advices.get_slice(&[out_dims + 1..out_dims + 2], &[out_dims]),
             );
 
-            let l1: EltwiseConfig<F, BITS, ReLu<F>> = EltwiseConfig::configure(
-                cs,
-                advices.get_slice(&[0..out_dims], &[1, out_dims]),
-                None,
-            );
+            let l1: EltwiseConfig<F, BITS, ReLu<F>> =
+                EltwiseConfig::configure(cs, advices.get_slice(&[0..out_dims], &[out_dims]), None);
 
             let public_output: Column<Instance> = cs.instance_column();
             cs.enable_equality(public_output);
@@ -115,11 +112,9 @@ mod onnx_example {
         let onnx_model = OnnxModel::new("examples/onnx_models/ff.onnx");
 
         let l0_kernel = onnx_model.get_tensor_by_node_name("fc1.weight", 0f32, 256f32);
-        let mut l0_bias = onnx_model.get_tensor_by_node_name("fc1.bias", 0f32, 256f32);
-        l0_bias.reshape(&[1, 4]);
+        let l0_bias = onnx_model.get_tensor_by_node_name("fc1.bias", 0f32, 256f32);
 
-        let mut input = Tensor::<i32>::new(Some(&[-30, -21, 11]), &[1, 3]).unwrap();
-        input.reshape(&[1, 3]);
+        let input = Tensor::<i32>::new(Some(&[-30, -21, 11]), &[3]).unwrap();
 
         let circuit = MyCircuit::<F, 14> {
             input,

--- a/examples/smallonnx.rs
+++ b/examples/smallonnx.rs
@@ -41,8 +41,7 @@ mod onnx_example {
             let onnx_model = OnnxModel::new("examples/onnx_models/ff.onnx");
             let l0_kernel = onnx_model.get_tensor_by_node_name("fc1.weight", 0f32, 256f32);
             let shape = l0_kernel.dims();
-            let in_dims = shape[1];
-            let out_dims = shape[0];
+            let (out_dims, in_dims) = (shape[0], shape[1]);
 
             let advices = VarTensor::from(Tensor::from((0..out_dims + 3).map(|_| {
                 let col = cs.advice_column();

--- a/src/nn/affine.rs
+++ b/src/nn/affine.rs
@@ -28,13 +28,14 @@ impl<F: FieldExt + TensorType> LayerConfig<F> for Affine1dConfig<F> {
         output: VarTensor,
     ) -> Self {
         assert!(params.len() == 2);
-        let in_dim = input.dims()[0];
 
         let (kernel, bias) = (params[0].clone(), params[1].clone());
 
-        assert_eq!(kernel.dims()[1], in_dim);
+        assert_eq!(kernel.dims()[1], input.dims()[0]);
         assert_eq!(kernel.dims()[0], output.dims()[0]);
         assert_eq!(kernel.dims()[0], bias.dims()[0]);
+
+        let in_dim = input.dims()[0];
 
         let config = Self {
             selector: meta.selector(),
@@ -74,7 +75,7 @@ impl<F: FieldExt + TensorType> LayerConfig<F> for Affine1dConfig<F> {
         input: ValTensor<F>,
         params: &[ValTensor<F>],
     ) -> Tensor<AssignedCell<Assigned<F>, F>> {
-        assert!(params.len() == 2);
+        assert_eq!(params.len(), 2);
 
         let (kernel, bias) = (params[0].clone(), params[1].clone());
         layouter
@@ -83,19 +84,18 @@ impl<F: FieldExt + TensorType> LayerConfig<F> for Affine1dConfig<F> {
                 |mut region| {
                     let offset = 0;
                     self.selector.enable(&mut region, offset)?;
-
                     let input = self.input.assign(&mut region, offset, input.clone());
                     let weights = self.kernel.assign(&mut region, offset, kernel.clone());
-
                     let bias = self.bias.assign(&mut region, offset, bias.clone());
                     // calculate value of output
                     let mut output: Tensor<Value<Assigned<F>>> =
                         Tensor::new(None, &[kernel.dims()[0]]).unwrap();
 
                     output = output.enum_map(|i, mut o| {
-                        for (j, x) in input.iter().enumerate() {
+                        input.enum_map(|j, x| {
                             o = o + x.value_field() * weights.get(&[i, j]).value_field();
-                        }
+                        });
+
                         o + bias.get(&[i]).value_field()
                     });
 

--- a/src/nn/cnvrl.rs
+++ b/src/nn/cnvrl.rs
@@ -153,7 +153,7 @@ where
                 &[kernel.get_slice(&[i..i + 1])],
             )
         }));
-        let mut t = t.flatten();
+        let mut t = t.combine();
         t.reshape(&[out_channels, horz, vert]);
         ValTensor::from(t)
     }

--- a/src/nn/cnvrl.rs
+++ b/src/nn/cnvrl.rs
@@ -57,17 +57,9 @@ where
             let image = config.image.query(meta, 0);
             let kernel = config.kernel.query(meta, 0);
 
-            println!("{:?}, {:?}", image.dims(), kernel.dims());
-
             let expected_output = convolution::<_, PADDING, STRIDE>(kernel, image);
 
             let witnessed_output = config.output.query(meta, image_width);
-
-            println!(
-                "{:?}, {:?}",
-                expected_output.dims(),
-                witnessed_output.dims()
-            );
 
             let constraints = witnessed_output.enum_map(|i, o| o - expected_output[i].clone());
 
@@ -83,7 +75,7 @@ where
         input: ValTensor<F>,
         params: &[ValTensor<F>],
     ) -> Tensor<AssignedCell<Assigned<F>, F>> {
-        assert!(params.len() == 1);
+        assert_eq!(params.len(), 1);
         let kernel = params[0].clone();
         let image_width = input.dims()[2];
         layouter
@@ -134,7 +126,7 @@ where
         let mut t = self.assign(
             &mut layouter.namespace(|| format!("filter")),
             input.clone(),
-            &[kernel.clone()],
+            params,
         );
         t.reshape(&[out_channels, horz, vert]);
         ValTensor::from(t)

--- a/src/nn/io.rs
+++ b/src/nn/io.rs
@@ -142,7 +142,7 @@ impl<F: FieldExt + TensorType> IOConfig<F> {
     }
 }
 
-pub fn format_advice_coord(coord: &[usize]) -> Vec<usize> {
+fn format_advice_coord(coord: &[usize]) -> Vec<usize> {
     let last = coord.len() - 1;
     let mut v = coord.to_vec();
     if last == 0 {

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -344,7 +344,7 @@ impl<T: Clone + TensorType> Tensor<T> {
     /// ```
     /// use halo2deeplearning::tensor::Tensor;
     /// let mut a = Tensor::<i32>::new(Some(&[1, 4]), &[2]).unwrap();
-    /// let mut c = a.enum_map(|i, x| i32::pow(x + i as i32, 2));
+    /// let mut c = a.mc_enum_map(|i, x| i32::pow(x + i[0] as i32, 2));
     /// assert_eq!(c, Tensor::from([1, 25].into_iter()));
     /// ```
     pub fn mc_enum_map<F: FnMut(&[usize], T) -> G, G: TensorType>(&self, mut f: F) -> Tensor<G> {

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -339,6 +339,28 @@ impl<T: Clone + TensorType> Tensor<T> {
         t.reshape(self.dims());
         t
     }
+
+    /// Maps a function to tensors and enumerates using multi cartesian coordinates
+    /// ```
+    /// use halo2deeplearning::tensor::Tensor;
+    /// let mut a = Tensor::<i32>::new(Some(&[1, 4]), &[2]).unwrap();
+    /// let mut c = a.enum_map(|i, x| i32::pow(x + i as i32, 2));
+    /// assert_eq!(c, Tensor::from([1, 25].into_iter()));
+    /// ```
+    pub fn mc_enum_map<F: FnMut(&[usize], T) -> G, G: TensorType>(&self, mut f: F) -> Tensor<G> {
+        let mut indices = Vec::new();
+        for i in self.dims.clone() {
+            indices.push(0..i);
+        }
+        println!("indices {:?}", indices);
+
+        let mut res = Vec::new();
+        for coord in indices.iter().cloned().multi_cartesian_product() {
+            res.push(f(&coord, self.get(&coord)));
+        }
+
+        Tensor::new(Some(&res), self.dims()).unwrap()
+    }
 }
 
 impl<T: Clone + TensorType> Tensor<Tensor<T>> {

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -352,8 +352,6 @@ impl<T: Clone + TensorType> Tensor<T> {
         for i in self.dims.clone() {
             indices.push(0..i);
         }
-        println!("indices {:?}", indices);
-
         let mut res = Vec::new();
         for coord in indices.iter().cloned().multi_cartesian_product() {
             res.push(f(&coord, self.get(&coord)));

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -305,6 +305,17 @@ impl<T: Clone + TensorType> Tensor<T> {
         self.dims = Vec::from(new_dims);
     }
 
+    ///Flatten the tensor shape
+    /// ```
+    /// use halo2deeplearning::tensor::Tensor;
+    /// let mut a = Tensor::<f32>::new(None, &[3, 3, 3]).unwrap();
+    /// a.flatten();
+    /// assert_eq!(a.dims(), &[27]);
+    /// ```
+    pub fn flatten(&mut self) {
+        self.dims = Vec::from([self.dims.iter().product::<usize>()]);
+    }
+
     /// Maps a function to tensors
     /// ```
     /// use halo2deeplearning::tensor::Tensor;
@@ -337,10 +348,10 @@ impl<T: Clone + TensorType> Tensor<Tensor<T>> {
     /// let mut a = Tensor::<i32>::new(Some(&[1, 2, 3, 4, 5, 6]), &[2, 3]).unwrap();
     /// let mut b = Tensor::<i32>::new(Some(&[1, 4]), &[2, 1]).unwrap();
     /// let mut c = Tensor::new(Some(&[a,b]), &[2]).unwrap();
-    /// let mut d = c.flatten();
+    /// let mut d = c.combine();
     /// assert_eq!(d.dims(), &[8]);
     /// ```
-    pub fn flatten(&self) -> Tensor<T> {
+    pub fn combine(&self) -> Tensor<T> {
         let mut dims = 0;
         let mut inner = Vec::new();
         for mut t in self.inner.clone().into_iter() {

--- a/src/tensor/val.rs
+++ b/src/tensor/val.rs
@@ -87,6 +87,23 @@ impl<F: FieldExt + TensorType> ValTensor<F> {
         }
     }
 
+    pub fn flatten(&mut self) {
+        match self {
+            ValTensor::Value { inner: v, dims: d } => {
+                v.flatten();
+                *d = v.dims().to_vec();
+            }
+            ValTensor::AssignedValue { inner: v, dims: d } => {
+                v.flatten();
+                *d = v.dims().to_vec();
+            }
+            ValTensor::PrevAssigned { inner: v, dims: d } => {
+                v.flatten();
+                *d = v.dims().to_vec();
+            }
+        }
+    }
+
     pub fn dims(&self) -> &[usize] {
         match self {
             ValTensor::Value { inner: _, dims: d } => d,

--- a/src/tensor/var.rs
+++ b/src/tensor/var.rs
@@ -44,6 +44,19 @@ impl VarTensor {
         }
     }
 
+    pub fn reshape(&mut self, new_dims: &[usize]) {
+        match self {
+            VarTensor::Advice { inner: _, dims: d } => {
+                assert!(d.iter().product::<usize>() == new_dims.iter().product());
+                *d = new_dims.to_vec();
+            }
+            VarTensor::Fixed { inner: _, dims: d } => {
+                assert!(d.iter().product::<usize>() == new_dims.iter().product());
+                *d = new_dims.to_vec();
+            }
+        }
+    }
+
     pub fn enable_equality<F: FieldExt>(&self, meta: &mut ConstraintSystem<F>) {
         match self {
             VarTensor::Advice {

--- a/src/tensor/var.rs
+++ b/src/tensor/var.rs
@@ -38,7 +38,6 @@ impl VarTensor {
                 if new_dims.len() > 1 {
                     new_inner.reshape(&new_dims[0..new_dims.len() - 1]);
                 }
-                println!("after {:?}", new_inner);
                 VarTensor::Advice {
                     inner: new_inner,
                     dims: new_dims.to_vec(),

--- a/src/tensor/var.rs
+++ b/src/tensor/var.rs
@@ -33,10 +33,17 @@ impl From<Tensor<Column<Fixed>>> for VarTensor {
 impl VarTensor {
     pub fn get_slice(&self, indices: &[Range<usize>], new_dims: &[usize]) -> VarTensor {
         match self {
-            VarTensor::Advice { inner: v, dims: _ } => VarTensor::Advice {
-                inner: v.get_slice(indices),
-                dims: new_dims.to_vec(),
-            },
+            VarTensor::Advice { inner: v, dims: _ } => {
+                let mut new_inner = v.get_slice(indices);
+                if new_dims.len() > 1 {
+                    new_inner.reshape(&new_dims[0..new_dims.len() - 1]);
+                }
+                println!("after {:?}", new_inner);
+                VarTensor::Advice {
+                    inner: new_inner,
+                    dims: new_dims.to_vec(),
+                }
+            }
             VarTensor::Fixed { inner: v, dims: _ } => VarTensor::Fixed {
                 inner: v.get_slice(indices),
                 dims: new_dims.to_vec(),

--- a/src/tensor_ops/mod.rs
+++ b/src/tensor_ops/mod.rs
@@ -48,8 +48,6 @@ pub fn convolution<
 
     let padded_image = pad::<T, PADDING>(image.clone());
 
-    println!("{:?} {:?}", padded_image.dims(), image_dims);
-
     let horz_slides = (image_height + 2 * PADDING - kernel_height) / STRIDE + 1;
     let vert_slides = (image_width + 2 * PADDING - kernel_width) / STRIDE + 1;
 

--- a/src/tensor_ops/mod.rs
+++ b/src/tensor_ops/mod.rs
@@ -31,30 +31,49 @@ pub fn convolution<
     kernel: Tensor<T>,
     image: Tensor<T>,
 ) -> Tensor<T> {
-    let padded_image = pad::<T, PADDING>(image.clone());
-
     let image_dims = image.dims();
     let kernel_dims = kernel.dims();
-    let horz_slides = (image_dims[0] + 2 * PADDING - kernel_dims[0]) / STRIDE + 1;
-    let vert_slides = (image_dims[1] + 2 * PADDING - kernel_dims[1]) / STRIDE + 1;
+    assert_eq!(image_dims.len(), 3);
+    assert_eq!(kernel_dims.len(), 4);
+    assert_eq!(image_dims[0], kernel_dims[1]);
+
+    let (output_channels, input_channels, kernel_height, kernel_width) = (
+        kernel_dims[0],
+        kernel_dims[1],
+        kernel_dims[2],
+        kernel_dims[3],
+    );
+
+    let (image_height, image_width) = (image_dims[1], image_dims[2]);
+
+    let padded_image = pad::<T, PADDING>(image.clone());
+
+    println!("{:?} {:?}", padded_image.dims(), image_dims);
+
+    let horz_slides = (image_height + 2 * PADDING - kernel_height) / STRIDE + 1;
+    let vert_slides = (image_width + 2 * PADDING - kernel_width) / STRIDE + 1;
 
     // calculate value of output
-    let mut output: Tensor<T> = Tensor::new(None, &[horz_slides, vert_slides]).unwrap();
+    let mut output: Tensor<T> =
+        Tensor::new(None, &[output_channels, horz_slides, vert_slides]).unwrap();
 
-    for horz_slide in 0..horz_slides {
-        let col_start = horz_slide * STRIDE;
-        for vert_slide in 0..vert_slides {
-            let row_start = vert_slide * STRIDE;
-            output.set(
-                &[horz_slide, vert_slide],
-                dot_product(
-                    kernel.clone(),
-                    padded_image.get_slice(&[
-                        col_start..(col_start + kernel_dims[0]),
-                        row_start..(row_start + kernel_dims[1]),
-                    ]),
-                ),
-            );
+    for i in 0..output_channels {
+        for j in 0..horz_slides {
+            let rs = j * STRIDE;
+            for k in 0..vert_slides {
+                let cs = k * STRIDE;
+                output.set(
+                    &[i, j, k],
+                    dot_product(
+                        kernel.get_slice(&[i..i + 1]).clone(),
+                        padded_image.get_slice(&[
+                            0..input_channels,
+                            rs..(rs + kernel_height),
+                            cs..(cs + kernel_width),
+                        ]),
+                    ),
+                );
+            }
         }
     }
     output
@@ -70,21 +89,25 @@ pub fn dot_product<T: TensorType + Mul<Output = T> + Add<Output = T>>(
 }
 
 fn pad<T: TensorType, const PADDING: usize>(image: Tensor<T>) -> Tensor<T> {
-    let padded_height = image.dims()[0] + 2 * PADDING;
-    let padded_width = image.dims()[1] + 2 * PADDING;
+    assert_eq!(image.dims().len(), 3);
+    let (channels, height, width) = (image.dims()[0], image.dims()[1], image.dims()[2]);
+    let padded_height = height + 2 * PADDING;
+    let padded_width = width + 2 * PADDING;
 
-    let mut output = Tensor::<T>::new(None, &[padded_height, padded_width]).unwrap();
+    let mut output = Tensor::<T>::new(None, &[channels, padded_height, padded_width]).unwrap();
 
-    for col in 0..image.dims()[0] {
-        for row in 0..image.dims()[1] {
-            output.set(
-                &[col + PADDING, row + PADDING],
-                image.get(&[col, row]).clone(),
-            );
+    for channel in 0..channels {
+        for col in 0..height {
+            for row in 0..width {
+                output.set(
+                    &[channel, col + PADDING, row + PADDING],
+                    image.get(&[channel, col, row]).clone(),
+                );
+            }
         }
     }
 
-    output.reshape(&[padded_height, padded_width]);
+    output.reshape(&[channels, padded_height, padded_width]);
     output
 }
 


### PR DESCRIPTION
- removes input channels as generic on conv layers using:
    -   4D kernels convolved with 3D inputs in `tensor_ops::convolution`
    - allowing for N-d vectors on IOconfig (i.e N-d advice vectors, N-d inputs, N-d kernels)
    - removing `[1,len]` shape requirement for 1-D input

**NOTE:** Swaps width and Height dims to be closer to `pytorch` norm

Resolves #18
