### PR TITLE
refactor: eltwise as layer

### DIFF
--- a/benches/affine.rs
+++ b/benches/affine.rs
@@ -57,9 +57,10 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
         config.layout(
             &mut layouter,
             &[
-                self.input.clone(),
+
                 self.l0_params[0].clone(),
                 self.l0_params[1].clone(),
+                self.input.clone(),
             ],
         );
         Ok(())

--- a/benches/affine.rs
+++ b/benches/affine.rs
@@ -45,7 +45,7 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
 
         Self::Config::configure(
             cs,
-            &[kernel.clone(), bias.clone(), input.clone(), output.clone()],
+            &[kernel.clone(), bias.clone(), input.clone(), output.clone()], None
         )
     }
 

--- a/benches/affine.rs
+++ b/benches/affine.rs
@@ -40,12 +40,12 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
 
         let kernel = advices.get_slice(&[0..len], &[len, len]);
         let bias = advices.get_slice(&[len + 2..len + 3], &[len]);
+        let input = advices.get_slice(&[len..len + 1], &[len]);
+        let output = advices.get_slice(&[len + 1..len + 2], &[len]);
 
         Self::Config::configure(
             cs,
-            &[kernel.clone(), bias.clone()],
-            advices.get_slice(&[len..len + 1], &[len]),
-            advices.get_slice(&[len + 1..len + 2], &[len]),
+            &[kernel.clone(), bias.clone(), input.clone(), output.clone()],
         )
     }
 
@@ -54,7 +54,14 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
-        config.layout(&mut layouter, self.input.clone(), &self.l0_params);
+        config.layout(
+            &mut layouter,
+            &[
+                self.input.clone(),
+                self.l0_params[0].clone(),
+                self.l0_params[1].clone(),
+            ],
+        );
         Ok(())
     }
 }

--- a/benches/cnvrl.rs
+++ b/benches/cnvrl.rs
@@ -79,7 +79,7 @@ where
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
-        let _output = config.layout(&mut layouter, &[self.image.clone(), self.kernels.clone()]);
+        let _output = config.layout(&mut layouter, &[self.kernels.clone(), self.image.clone()]);
         Ok(())
     }
 }

--- a/benches/cnvrl.rs
+++ b/benches/cnvrl.rs
@@ -59,15 +59,17 @@ where
 
             Self::Config::configure(
                 meta,
-                &[VarTensor::from(kernel)],
-                advices.get_slice(
-                    &[0..IMAGE_HEIGHT * IN_CHANNELS],
-                    &[IN_CHANNELS, IMAGE_HEIGHT, IMAGE_WIDTH],
-                ),
-                advices.get_slice(
-                    &[0..output_height * OUT_CHANNELS],
-                    &[OUT_CHANNELS, output_height, output_width],
-                ),
+                &[
+                    VarTensor::from(kernel),
+                    advices.get_slice(
+                        &[0..IMAGE_HEIGHT * IN_CHANNELS],
+                        &[IN_CHANNELS, IMAGE_HEIGHT, IMAGE_WIDTH],
+                    ),
+                    advices.get_slice(
+                        &[0..output_height * OUT_CHANNELS],
+                        &[OUT_CHANNELS, output_height, output_width],
+                    ),
+                ],
             )
         }
     }
@@ -77,7 +79,7 @@ where
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
-        let _output = config.layout(&mut layouter, self.image.clone(), &[self.kernels.clone()]);
+        let _output = config.layout(&mut layouter, &[self.image.clone(), self.kernels.clone()]);
         Ok(())
     }
 }

--- a/benches/cnvrl.rs
+++ b/benches/cnvrl.rs
@@ -34,7 +34,7 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F>
 where
     Value<F>: TensorType,
 {
-    type Config = ConvConfig<F, STRIDE, PADDING>;
+    type Config = ConvConfig<F>;
     type FloorPlanner = SimpleFloorPlanner;
 
     fn without_witnesses(&self) -> Self {
@@ -70,6 +70,7 @@ where
                         &[OUT_CHANNELS, output_height, output_width],
                     ),
                 ],
+                Some(&[PADDING, STRIDE]),
             )
         }
     }

--- a/benches/relu.rs
+++ b/benches/relu.rs
@@ -6,8 +6,9 @@ use halo2_proofs::{
     plonk::{Circuit, ConstraintSystem, Error},
 };
 use halo2curves::pasta::Fp as F;
+use halo2deeplearning::nn::eltwise::{EltwiseConfig, Nonlin1d, Nonlinearity, ReLu};
+use halo2deeplearning::nn::LayerConfig;
 use halo2deeplearning::tensor::*;
-use halo2deeplearning::tensor_ops::eltwise::{EltwiseConfig, Nonlin1d, Nonlinearity, ReLu};
 use rand::Rng;
 use std::marker::PhantomData;
 
@@ -36,7 +37,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F> + Clone> Circuit<F>
                 inner: (0..LEN).map(|_| cs.advice_column()).into(),
                 dims: [LEN].to_vec(),
             };
-            Self::Config::configure(cs, advices, None)
+            Self::Config::configure(cs, &[advices])
         }
     }
 
@@ -45,7 +46,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F> + Clone> Circuit<F>
         config: Self::Config,
         mut layouter: impl Layouter<F>, // layouter is our 'write buffer' for the circuit
     ) -> Result<(), Error> {
-        config.layout(&mut layouter, self.assigned.input.clone());
+        config.layout(&mut layouter, &[self.assigned.input.clone()]);
 
         Ok(())
     }

--- a/benches/relu.rs
+++ b/benches/relu.rs
@@ -24,7 +24,7 @@ struct NLCircuit<F: FieldExt + TensorType, NL: Nonlinearity<F>> {
 impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F> + Clone> Circuit<F>
     for NLCircuit<F, NL>
 {
-    type Config = EltwiseConfig<F, BITS, NL>;
+    type Config = EltwiseConfig<F, NL>;
     type FloorPlanner = SimpleFloorPlanner;
 
     fn without_witnesses(&self) -> Self {
@@ -37,7 +37,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F> + Clone> Circuit<F>
                 inner: (0..LEN).map(|_| cs.advice_column()).into(),
                 dims: [LEN].to_vec(),
             };
-            Self::Config::configure(cs, &[advices], None)
+            Self::Config::configure(cs, &[advices], Some(&[BITS]))
         }
     }
 

--- a/benches/relu.rs
+++ b/benches/relu.rs
@@ -37,7 +37,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F> + Clone> Circuit<F>
                 inner: (0..LEN).map(|_| cs.advice_column()).into(),
                 dims: [LEN].to_vec(),
             };
-            Self::Config::configure(cs, &[advices])
+            Self::Config::configure(cs, &[advices], None)
         }
     }
 

--- a/examples/conv2d_mnist/main.rs
+++ b/examples/conv2d_mnist/main.rs
@@ -53,8 +53,8 @@ struct Config<
     Value<F>: TensorType,
 {
     l0: ConvConfig<F>,
-    l0q: EltwiseConfig<F, BITS, DivideBy<F, 32>>,
-    l1: EltwiseConfig<F, BITS, ReLu<F>>,
+    l0q: EltwiseConfig<F, DivideBy<F, 32>>,
+    l1: EltwiseConfig<F, ReLu<F>>,
     l2: Affine1dConfig<F>,
     public_output: Column<Instance>,
 }
@@ -175,10 +175,10 @@ where
             Some(&[PADDING, STRIDE]),
         );
 
-        let l0q: EltwiseConfig<F, BITS, DivideBy<F, 32>> =
-            EltwiseConfig::configure(cs, &[advices.get_slice(&[0..LEN], &[LEN])], None);
-        let l1: EltwiseConfig<F, BITS, ReLu<F>> =
-            EltwiseConfig::configure(cs, &[advices.get_slice(&[0..LEN], &[LEN])], None);
+        let l0q: EltwiseConfig<F, DivideBy<F, 32>> =
+            EltwiseConfig::configure(cs, &[advices.get_slice(&[0..LEN], &[LEN])], Some(&[BITS]));
+        let l1: EltwiseConfig<F, ReLu<F>> =
+            EltwiseConfig::configure(cs, &[advices.get_slice(&[0..LEN], &[LEN])], Some(&[BITS]));
 
         let l2: Affine1dConfig<F> = Affine1dConfig::configure(
             cs,

--- a/examples/conv2d_mnist/main.rs
+++ b/examples/conv2d_mnist/main.rs
@@ -207,13 +207,13 @@ where
     ) -> Result<(), Error> {
         let x = config
             .l0
-            .layout(&mut layouter, &[self.input.clone(), self.l0_params.clone()]);
+            .layout(&mut layouter, &[self.l0_params.clone(), self.input.clone()]);
         let x = config.l0q.layout(&mut layouter, &[x]);
         let mut x = config.l1.layout(&mut layouter, &[x]);
         x.flatten();
         let l2out = config.l2.layout(
             &mut layouter,
-            &[x, self.l2_params[0].clone(), self.l2_params[1].clone()],
+            &[self.l2_params[0].clone(), self.l2_params[1].clone(), x],
         );
 
         match l2out {

--- a/examples/mlp_4d.rs
+++ b/examples/mlp_4d.rs
@@ -7,9 +7,9 @@ use halo2_proofs::{
 use halo2curves::pasta::Fp as F;
 use halo2deeplearning::fieldutils::i32_to_felt;
 use halo2deeplearning::nn::affine::Affine1dConfig;
+use halo2deeplearning::nn::eltwise::{DivideBy, EltwiseConfig, ReLu};
 use halo2deeplearning::nn::*;
 use halo2deeplearning::tensor::*;
-use halo2deeplearning::tensor_ops::eltwise::{DivideBy, EltwiseConfig, ReLu};
 use std::marker::PhantomData;
 
 // A columnar ReLu MLP
@@ -25,15 +25,15 @@ struct MyConfig<F: FieldExt + TensorType, const BITS: usize> {
 
 #[derive(Clone)]
 struct MyCircuit<
-    F: FieldExt,
+    F: FieldExt + TensorType,
     const LEN: usize, //LEN = CHOUT x OH x OW flattened
     const BITS: usize,
 > {
     // Given the stateless MyConfig type information, a DNN trace is determined by its input and the parameters of its layers.
     // Computing the trace still requires a forward pass. The intermediate activations are stored only by the layouter.
-    input: Tensor<i32>,
-    l0_params: [Tensor<i32>; 2],
-    l2_params: [Tensor<i32>; 2],
+    input: ValTensor<F>,
+    l0_params: [ValTensor<F>; 2],
+    l2_params: [ValTensor<F>; 2],
     _marker: PhantomData<F>,
 }
 
@@ -58,28 +58,23 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
 
         let kernel = advices.get_slice(&[0..LEN], &[LEN, LEN]);
         let bias = advices.get_slice(&[LEN + 2..LEN + 3], &[LEN]);
+        let input = advices.get_slice(&[LEN..LEN + 1], &[LEN]);
+        let output = advices.get_slice(&[LEN + 1..LEN + 2], &[LEN]);
 
         let l0 = Affine1dConfig::<F>::configure(
             cs,
-            &[kernel.clone(), bias.clone()],
-            advices.get_slice(&[LEN..LEN + 1], &[LEN]),
-            advices.get_slice(&[LEN + 1..LEN + 2], &[LEN]),
+            &[kernel.clone(), bias.clone(), input.clone(), output.clone()],
         );
 
-        let l2 = Affine1dConfig::<F>::configure(
-            cs,
-            &[kernel, bias],
-            advices.get_slice(&[LEN..LEN + 1], &[LEN]),
-            advices.get_slice(&[LEN + 1..LEN + 2], &[LEN]),
-        );
+        let l2 = Affine1dConfig::<F>::configure(cs, &[kernel, bias, input, output]);
 
         // sets up a new ReLU table and resuses it for l1 and l3 non linearities
         let [l1, l3]: [EltwiseConfig<F, BITS, ReLu<F>>; 2] =
-            EltwiseConfig::configure_multiple(cs, advices.get_slice(&[0..LEN], &[LEN]));
+            EltwiseConfig::configure_multiple(cs, &[advices.get_slice(&[0..LEN], &[LEN])]);
 
         // sets up a new Divide by table
         let l4: EltwiseConfig<F, BITS, DivideBy<F, 128>> =
-            EltwiseConfig::configure(cs, advices.get_slice(&[0..LEN], &[LEN]), None);
+            EltwiseConfig::configure(cs, &[advices.get_slice(&[0..LEN], &[LEN])]);
 
         let public_output: Column<Instance> = cs.instance_column();
         cs.enable_equality(public_output);
@@ -99,28 +94,21 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
-        let x: Tensor<Value<F>> = self.input.clone().into();
         let x = config.l0.layout(
             &mut layouter,
-            ValTensor::from(x),
-            &self
-                .l0_params
-                .iter()
-                .map(|a| ValTensor::from(<Tensor<i32> as Into<Tensor<Value<F>>>>::into(a.clone())))
-                .collect::<Vec<ValTensor<F>>>(),
+            &[
+                self.input.clone(),
+                self.l0_params[0].clone(),
+                self.l0_params[1].clone(),
+            ],
         );
-        let x = config.l1.layout(&mut layouter, x);
+        let x = config.l1.layout(&mut layouter, &[x]);
         let x = config.l2.layout(
             &mut layouter,
-            x,
-            &self
-                .l2_params
-                .iter()
-                .map(|a| ValTensor::from(<Tensor<i32> as Into<Tensor<Value<F>>>>::into(a.clone())))
-                .collect::<Vec<ValTensor<F>>>(),
+            &[x, self.l2_params[0].clone(), self.l2_params[1].clone()],
         );
-        let x = config.l3.layout(&mut layouter, x);
-        let x = config.l4.layout(&mut layouter, x);
+        let x = config.l3.layout(&mut layouter, &[x]);
+        let x = config.l4.layout(&mut layouter, &[x]);
         match x {
             ValTensor::PrevAssigned { inner: v, dims: _ } => v.enum_map(|i, x| {
                 layouter
@@ -136,26 +124,34 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
 pub fn runmlp() {
     let k = 15; //2^k rows
                 // parameters
-    let l0_kernel = Tensor::<i32>::new(
+    let l0_kernel: Tensor<Value<F>> = Tensor::<i32>::new(
         Some(&[10, 0, 0, -1, 0, 10, 1, 0, 0, 1, 10, 0, 1, 0, 0, 10]),
         &[4, 4],
     )
-    .unwrap();
-    let l0_bias = Tensor::<i32>::new(Some(&[0, 0, 0, 1]), &[4]).unwrap();
+    .unwrap()
+    .into();
+    let l0_bias: Tensor<Value<F>> = Tensor::<i32>::new(Some(&[0, 0, 0, 1]), &[4])
+        .unwrap()
+        .into();
 
-    let l2_kernel = Tensor::<i32>::new(
+    let l2_kernel: Tensor<Value<F>> = Tensor::<i32>::new(
         Some(&[0, 3, 10, -1, 0, 10, 1, 0, 0, 1, 0, 12, 1, -2, 32, 0]),
         &[4, 4],
     )
-    .unwrap();
+    .unwrap()
+    .into();
     // input data, with 1 padding to allow for bias
-    let input = Tensor::<i32>::new(Some(&[-30, -21, 11, 40]), &[4]).unwrap();
-    let l2_bias = Tensor::<i32>::new(Some(&[0, 0, 0, 1]), &[4]).unwrap();
+    let input: Tensor<Value<F>> = Tensor::<i32>::new(Some(&[-30, -21, 11, 40]), &[4])
+        .unwrap()
+        .into();
+    let l2_bias: Tensor<Value<F>> = Tensor::<i32>::new(Some(&[0, 0, 0, 1]), &[4])
+        .unwrap()
+        .into();
 
     let circuit = MyCircuit::<F, 4, 14> {
-        input,
-        l0_params: [l0_kernel, l0_bias],
-        l2_params: [l2_kernel, l2_bias],
+        input: input.into(),
+        l0_params: [l0_kernel.into(), l0_bias.into()],
+        l2_params: [l2_kernel.into(), l2_bias.into()],
         _marker: PhantomData,
     };
 

--- a/examples/mlp_4d.rs
+++ b/examples/mlp_4d.rs
@@ -97,15 +97,15 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
         let x = config.l0.layout(
             &mut layouter,
             &[
-                self.input.clone(),
                 self.l0_params[0].clone(),
                 self.l0_params[1].clone(),
+                self.input.clone(),
             ],
         );
         let x = config.l1.layout(&mut layouter, &[x]);
         let x = config.l2.layout(
             &mut layouter,
-            &[x, self.l2_params[0].clone(), self.l2_params[1].clone()],
+            &[ self.l2_params[0].clone(), self.l2_params[1].clone(), x],
         );
         let x = config.l3.layout(&mut layouter, &[x]);
         let x = config.l4.layout(&mut layouter, &[x]);

--- a/examples/mlp_4d.rs
+++ b/examples/mlp_4d.rs
@@ -64,9 +64,10 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
         let l0 = Affine1dConfig::<F>::configure(
             cs,
             &[kernel.clone(), bias.clone(), input.clone(), output.clone()],
+            None
         );
 
-        let l2 = Affine1dConfig::<F>::configure(cs, &[kernel, bias, input, output]);
+        let l2 = Affine1dConfig::<F>::configure(cs, &[kernel, bias, input, output], None);
 
         // sets up a new ReLU table and resuses it for l1 and l3 non linearities
         let [l1, l3]: [EltwiseConfig<F, BITS, ReLu<F>>; 2] =
@@ -74,7 +75,7 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
 
         // sets up a new Divide by table
         let l4: EltwiseConfig<F, BITS, DivideBy<F, 128>> =
-            EltwiseConfig::configure(cs, &[advices.get_slice(&[0..LEN], &[LEN])]);
+            EltwiseConfig::configure(cs, &[advices.get_slice(&[0..LEN], &[LEN])], None);
 
         let public_output: Column<Instance> = cs.instance_column();
         cs.enable_equality(public_output);
@@ -105,7 +106,7 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
         let x = config.l1.layout(&mut layouter, &[x]);
         let x = config.l2.layout(
             &mut layouter,
-            &[ self.l2_params[0].clone(), self.l2_params[1].clone(), x],
+            &[self.l2_params[0].clone(), self.l2_params[1].clone(), x],
         );
         let x = config.l3.layout(&mut layouter, &[x]);
         let x = config.l4.layout(&mut layouter, &[x]);

--- a/examples/smallonnx.rs
+++ b/examples/smallonnx.rs
@@ -60,10 +60,14 @@ mod onnx_example {
                     advices.get_slice(&[out_dims..out_dims + 1], &[in_dims]),
                     advices.get_slice(&[out_dims + 1..out_dims + 2], &[out_dims]),
                 ],
+                None,
             );
 
-            let l1: EltwiseConfig<F, BITS, ReLu<F>> =
-                EltwiseConfig::configure(cs, &[advices.get_slice(&[0..out_dims], &[out_dims])]);
+            let l1: EltwiseConfig<F, BITS, ReLu<F>> = EltwiseConfig::configure(
+                cs,
+                &[advices.get_slice(&[0..out_dims], &[out_dims])],
+                None,
+            );
 
             let public_output: Column<Instance> = cs.instance_column();
             cs.enable_equality(public_output);
@@ -83,7 +87,6 @@ mod onnx_example {
             let x = config.l0.layout(
                 &mut layouter,
                 &[
-
                     self.l0_params[0].clone(),
                     self.l0_params[1].clone(),
                     self.input.clone(),

--- a/examples/smallonnx.rs
+++ b/examples/smallonnx.rs
@@ -18,7 +18,7 @@ mod onnx_example {
     #[derive(Clone)]
     struct MyConfig<F: FieldExt + TensorType, const BITS: usize> {
         l0: Affine1dConfig<F>,
-        l1: EltwiseConfig<F, BITS, ReLu<F>>,
+        l1: EltwiseConfig<F, ReLu<F>>,
         public_output: Column<Instance>,
     }
 
@@ -63,10 +63,10 @@ mod onnx_example {
                 None,
             );
 
-            let l1: EltwiseConfig<F, BITS, ReLu<F>> = EltwiseConfig::configure(
+            let l1: EltwiseConfig<F, ReLu<F>> = EltwiseConfig::configure(
                 cs,
                 &[advices.get_slice(&[0..out_dims], &[out_dims])],
-                None,
+                Some(&[BITS]),
             );
 
             let public_output: Column<Instance> = cs.instance_column();

--- a/examples/smallonnx.rs
+++ b/examples/smallonnx.rs
@@ -9,10 +9,10 @@ mod onnx_example {
     use halo2curves::pasta::Fp as F;
     use halo2deeplearning::fieldutils::i32_to_felt;
     use halo2deeplearning::nn::affine::Affine1dConfig;
+    use halo2deeplearning::nn::eltwise::{EltwiseConfig, ReLu};
     use halo2deeplearning::nn::*;
     use halo2deeplearning::onnx::OnnxModel;
     use halo2deeplearning::tensor::{Tensor, TensorType, ValTensor, VarTensor};
-    use halo2deeplearning::nn::eltwise::{EltwiseConfig, ReLu};
     use std::marker::PhantomData;
 
     #[derive(Clone)]
@@ -83,9 +83,10 @@ mod onnx_example {
             let x = config.l0.layout(
                 &mut layouter,
                 &[
-                    self.input.clone(),
+
                     self.l0_params[0].clone(),
                     self.l0_params[1].clone(),
+                    self.input.clone(),
                 ],
             );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,3 @@ pub mod nn;
 pub mod onnx;
 /// An implementation of multi-dimensional tensors.
 pub mod tensor;
-/// Implementations of common operations on tensors.
-pub mod tensor_ops;

--- a/src/nn/affine.rs
+++ b/src/nn/affine.rs
@@ -22,15 +22,15 @@ pub struct Affine1dConfig<F: FieldExt + TensorType> {
 impl<F: FieldExt + TensorType> LayerConfig<F> for Affine1dConfig<F> {
     /// Configures and creates an affine gate within a circuit.
     /// Also constrains the output of the gate.
-    fn configure(
-        meta: &mut ConstraintSystem<F>,
-        params: &[VarTensor],
-        input: VarTensor,
-        output: VarTensor,
-    ) -> Self {
-        assert!(params.len() == 2);
+    fn configure(meta: &mut ConstraintSystem<F>, variables: &[VarTensor]) -> Self {
+        assert_eq!(variables.len(), 4);
 
-        let (kernel, bias) = (params[0].clone(), params[1].clone());
+        let (kernel, bias, input, output) = (
+            variables[0].clone(),
+            variables[1].clone(),
+            variables[2].clone(),
+            variables[3].clone(),
+        );
 
         assert_eq!(kernel.dims()[1], input.dims()[0]);
         assert_eq!(kernel.dims()[0], output.dims()[0]);
@@ -70,15 +70,10 @@ impl<F: FieldExt + TensorType> LayerConfig<F> for Affine1dConfig<F> {
     }
 
     /// Assigns values to the affine gate variables created when calling `configure`.
-    fn layout(
-        &self,
-        layouter: &mut impl Layouter<F>,
-        input: ValTensor<F>,
-        params: &[ValTensor<F>],
-    ) -> ValTensor<F> {
-        assert_eq!(params.len(), 2);
+    fn layout(&self, layouter: &mut impl Layouter<F>, inputs: &[ValTensor<F>]) -> ValTensor<F> {
+        assert_eq!(inputs.len(), 3);
 
-        let (kernel, bias) = (params[0].clone(), params[1].clone());
+        let (input, kernel, bias) = (inputs[0].clone(), inputs[1].clone(), inputs[2].clone());
         let t = layouter
             .assign_region(
                 || "assign image and kernel",

--- a/src/nn/affine.rs
+++ b/src/nn/affine.rs
@@ -21,7 +21,7 @@ pub struct Affine1dConfig<F: FieldExt + TensorType> {
 
 impl<F: FieldExt + TensorType> LayerConfig<F> for Affine1dConfig<F> {
     /// Configures and creates an affine gate within a circuit.
-    /// Also constrains the output of the gate.
+    /// Variables are supplied as a 4-element array of `[weights, bias, input, output]` VarTensors.
     fn configure(meta: &mut ConstraintSystem<F>, variables: &[VarTensor]) -> Self {
         assert_eq!(variables.len(), 4);
 
@@ -70,10 +70,11 @@ impl<F: FieldExt + TensorType> LayerConfig<F> for Affine1dConfig<F> {
     }
 
     /// Assigns values to the affine gate variables created when calling `configure`.
+    /// Values are supplied as a 3-element array of `[weights, bias, input]` VarTensors.
     fn layout(&self, layouter: &mut impl Layouter<F>, values: &[ValTensor<F>]) -> ValTensor<F> {
         assert_eq!(values.len(), 3);
 
-        let (kernel, bias, input, ) = (values[0].clone(), values[1].clone(), values[2].clone());
+        let (kernel, bias, input) = (values[0].clone(), values[1].clone(), values[2].clone());
         let t = layouter
             .assign_region(
                 || "assign image and kernel",

--- a/src/nn/affine.rs
+++ b/src/nn/affine.rs
@@ -70,10 +70,10 @@ impl<F: FieldExt + TensorType> LayerConfig<F> for Affine1dConfig<F> {
     }
 
     /// Assigns values to the affine gate variables created when calling `configure`.
-    fn layout(&self, layouter: &mut impl Layouter<F>, inputs: &[ValTensor<F>]) -> ValTensor<F> {
-        assert_eq!(inputs.len(), 3);
+    fn layout(&self, layouter: &mut impl Layouter<F>, values: &[ValTensor<F>]) -> ValTensor<F> {
+        assert_eq!(values.len(), 3);
 
-        let (input, kernel, bias) = (inputs[0].clone(), inputs[1].clone(), inputs[2].clone());
+        let (kernel, bias, input, ) = (values[0].clone(), values[1].clone(), values[2].clone());
         let t = layouter
             .assign_region(
                 || "assign image and kernel",

--- a/src/nn/affine.rs
+++ b/src/nn/affine.rs
@@ -22,7 +22,11 @@ pub struct Affine1dConfig<F: FieldExt + TensorType> {
 impl<F: FieldExt + TensorType> LayerConfig<F> for Affine1dConfig<F> {
     /// Configures and creates an affine gate within a circuit.
     /// Variables are supplied as a 4-element array of `[weights, bias, input, output]` VarTensors.
-    fn configure(meta: &mut ConstraintSystem<F>, variables: &[VarTensor]) -> Self {
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        variables: &[VarTensor],
+        _: Option<&[usize]>,
+    ) -> Self {
         assert_eq!(variables.len(), 4);
 
         let (kernel, bias, input, output) = (

--- a/src/nn/cnvrl.rs
+++ b/src/nn/cnvrl.rs
@@ -1,6 +1,6 @@
 use super::*;
+use crate::tensor::ops::*;
 use crate::tensor::TensorType;
-use crate::tensor_ops::*;
 use halo2_proofs::{
     arithmetic::FieldExt,
     circuit::{Layouter, Value},

--- a/src/nn/cnvrl.rs
+++ b/src/nn/cnvrl.rs
@@ -119,8 +119,6 @@ where
             )
             .unwrap();
 
-        println!("{:?}", t.dims());
-
         ValTensor::from(t)
     }
 }

--- a/src/nn/cnvrl.rs
+++ b/src/nn/cnvrl.rs
@@ -27,7 +27,7 @@ where
     Value<F>: TensorType,
 {
     /// Configures and creates a convolution gate within a circuit.
-    /// Also constrains the output of the gate.
+    /// Variables are supplied as a 3-element array of `[kernel, input, output]` VarTensors.
     fn configure(meta: &mut ConstraintSystem<F>, variables: &[VarTensor]) -> Self {
         assert_eq!(variables.len(), 3);
         let (kernel, input, output) = (
@@ -73,6 +73,7 @@ where
     }
 
     /// Assigns values to the convolution gate variables created when calling `configure`.
+    /// Values are supplied as a 2-element array of `[kernel, input]` VarTensors.
     fn layout(&self, layouter: &mut impl Layouter<F>, values: &[ValTensor<F>]) -> ValTensor<F> {
         assert_eq!(values.len(), 2);
 

--- a/src/nn/cnvrl.rs
+++ b/src/nn/cnvrl.rs
@@ -102,9 +102,9 @@ where
                             ValTensor::Value { inner: k, dims: _ } => {
                                 convolution::<_, PADDING, STRIDE>(k, img)
                             }
-                            _ => panic!("not implemented"),
+                            _ => todo!(),
                         },
-                        _ => panic!("not implemented"),
+                        _ => todo!(),
                     };
 
                     Ok(self

--- a/src/nn/cnvrl.rs
+++ b/src/nn/cnvrl.rs
@@ -73,10 +73,10 @@ where
     }
 
     /// Assigns values to the convolution gate variables created when calling `configure`.
-    fn layout(&self, layouter: &mut impl Layouter<F>, inputs: &[ValTensor<F>]) -> ValTensor<F> {
-        assert_eq!(inputs.len(), 2);
+    fn layout(&self, layouter: &mut impl Layouter<F>, values: &[ValTensor<F>]) -> ValTensor<F> {
+        assert_eq!(values.len(), 2);
 
-        let (input, kernel) = (inputs[0].clone(), inputs[1].clone());
+        let (kernel, input) = (values[0].clone(), values[1].clone());
         let (image_height, image_width) = (input.dims()[1], input.dims()[2]);
         let (out_channels, kernel_height, kernel_width) =
             (kernel.dims()[0], kernel.dims()[2], kernel.dims()[3]);

--- a/src/nn/eltwise.rs
+++ b/src/nn/eltwise.rs
@@ -139,7 +139,7 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
                     });
                 });
             }
-            _ => panic!("not yet implemented"),
+            _ => todo!(),
         }
 
         Self {
@@ -186,7 +186,7 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
                                         .assign_advice(|| "input", advice[i], offset, || x)
                                         .unwrap()
                                 }),
-                                _ => panic!("not yet implemented"),
+                                _ => todo!(),
                             },
                             ValTensor::PrevAssigned { inner: v, dims: _ } => match &self.input {
                                 VarTensor::Advice {
@@ -200,7 +200,7 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
                                             .unwrap()
                                     })
                                 }
-                                _ => panic!("not yet implemented"),
+                                _ => todo!(),
                             },
                             ValTensor::Value { inner: v, dims: _ } => match &self.input {
                                 VarTensor::Advice {
@@ -212,7 +212,7 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
                                         .assign_advice(|| "input", advice[i], offset, || x.into())
                                         .unwrap()
                                 }),
-                                _ => panic!("not yet implemented"),
+                                _ => todo!(),
                             },
                         };
 
@@ -234,7 +234,7 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
                                     .unwrap()
                             })),
 
-                            _ => panic!("not yet implemented"),
+                            _ => todo!(),
                         }
                     },
                 )

--- a/src/nn/eltwise.rs
+++ b/src/nn/eltwise.rs
@@ -110,6 +110,7 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
         }
     }
 
+    /// Configures and creates an elementwise operation within a circuit using a supplied lookup table.
     fn configure_with_table(
         cs: &mut ConstraintSystem<F>,
         variables: &[VarTensor],
@@ -153,11 +154,15 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
 impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>> LayerConfig<F>
     for EltwiseConfig<F, BITS, NL>
 {
+    /// Configures and creates an elementwise operation within a circuit.
+    /// Variables are supplied as a 1-element array of `[input]` VarTensors.
     fn configure(cs: &mut ConstraintSystem<F>, variables: &[VarTensor]) -> Self {
         let table = Rc::new(RefCell::new(EltwiseTable::<F, BITS, NL>::configure(cs)));
         Self::configure_with_table(cs, variables, table)
     }
 
+    /// Assigns values to the variables created when calling `configure`.
+    /// Values are supplied as a 1-element array of `[input]` VarTensors.
     fn layout(&self, layouter: &mut impl Layouter<F>, values: &[ValTensor<F>]) -> ValTensor<F> {
         if !self.table.borrow().is_assigned {
             self.table.borrow_mut().layout(layouter)

--- a/src/nn/eltwise.rs
+++ b/src/nn/eltwise.rs
@@ -158,7 +158,7 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
         Self::configure_with_table(cs, variables, table)
     }
 
-    fn layout(&self, layouter: &mut impl Layouter<F>, inputs: &[ValTensor<F>]) -> ValTensor<F> {
+    fn layout(&self, layouter: &mut impl Layouter<F>, values: &[ValTensor<F>]) -> ValTensor<F> {
         if !self.table.borrow().is_assigned {
             self.table.borrow_mut().layout(layouter)
         }
@@ -170,7 +170,7 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
                         let offset = 0;
                         self.qlookup.enable(&mut region, offset)?;
 
-                        let w = match &inputs[0] {
+                        let w = match &values[0] {
                             ValTensor::AssignedValue { inner: v, dims: _ } => match &self.input {
                                 VarTensor::Advice {
                                     inner: advice,
@@ -235,7 +235,7 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
                 )
                 .unwrap(),
         );
-        t.reshape(inputs[0].dims());
+        t.reshape(values[0].dims());
         t
     }
 }

--- a/src/nn/eltwise.rs
+++ b/src/nn/eltwise.rs
@@ -95,7 +95,7 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
         let configs = (0..NUM)
             .map(|_| {
                 let l = match &table {
-                    None => Self::configure(cs, variables),
+                    None => Self::configure(cs, variables, None),
                     Some(t) => Self::configure_with_table(cs, variables, t.clone()),
                 };
                 table = Some(l.table.clone());
@@ -156,7 +156,11 @@ impl<F: FieldExt + TensorType, const BITS: usize, NL: 'static + Nonlinearity<F>>
 {
     /// Configures and creates an elementwise operation within a circuit.
     /// Variables are supplied as a 1-element array of `[input]` VarTensors.
-    fn configure(cs: &mut ConstraintSystem<F>, variables: &[VarTensor]) -> Self {
+    fn configure(
+        cs: &mut ConstraintSystem<F>,
+        variables: &[VarTensor],
+        _: Option<&[usize]>,
+    ) -> Self {
         let table = Rc::new(RefCell::new(EltwiseTable::<F, BITS, NL>::configure(cs)));
         Self::configure_with_table(cs, variables, table)
     }

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -16,15 +16,3 @@ pub trait LayerConfig<F: FieldExt + TensorType> {
     /// Takes in ValTensor inputs and assigns them to the variables created when calling configure().
     fn layout(&self, layouter: &mut impl Layouter<F>, inputs: &[ValTensor<F>]) -> ValTensor<F>;
 }
-
-pub enum LayerType<
-    F: FieldExt + TensorType,
-    const STRIDE: usize,
-    const PADDING: usize,
-    const BITS: usize,
-    NL: eltwise::Nonlinearity<F>,
-> {
-    Conv(cnvrl::ConvConfig<F, STRIDE, PADDING>),
-    Affine(affine::Affine1dConfig<F>),
-    Eltwise(eltwise::EltwiseConfig<F, BITS, NL>),
-}

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -12,7 +12,11 @@ pub trait LayerConfig<F: FieldExt + TensorType> {
     /// Takes in VarTensors and creates a series of operations (gates in Halo2 circuit nomenclature)
     /// to which we can add equality constraints (for proving).
     /// Produces a layer object with attributes we can then assign to when calling layout().
-    fn configure(_meta: &mut ConstraintSystem<F>, variables: &[VarTensor]) -> Self;
+    fn configure(
+        _meta: &mut ConstraintSystem<F>,
+        variables: &[VarTensor],
+        layer_params: Option<&[usize]>,
+    ) -> Self;
     /// Takes in ValTensor inputs and assigns them to the variables created when calling configure().
     fn layout(&self, layouter: &mut impl Layouter<F>, values: &[ValTensor<F>]) -> ValTensor<F>;
 }

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -14,5 +14,5 @@ pub trait LayerConfig<F: FieldExt + TensorType> {
     /// Produces a layer object with attributes we can then assign to when calling layout().
     fn configure(_meta: &mut ConstraintSystem<F>, variables: &[VarTensor]) -> Self;
     /// Takes in ValTensor inputs and assigns them to the variables created when calling configure().
-    fn layout(&self, layouter: &mut impl Layouter<F>, inputs: &[ValTensor<F>]) -> ValTensor<F>;
+    fn layout(&self, layouter: &mut impl Layouter<F>, values: &[ValTensor<F>]) -> ValTensor<F>;
 }

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -1,27 +1,30 @@
 use crate::tensor::*;
 use halo2_proofs::{arithmetic::FieldExt, circuit::Layouter, plonk::ConstraintSystem};
-
 /// Structs and methods for configuring and assigning to an affine gate within a Halo2 circuit.
 pub mod affine;
 /// Structs and methods for configuring and assigning to a convolutional gate within a Halo2 circuit.
 pub mod cnvrl;
+/// Element-wise operations.
+pub mod eltwise;
 
 /// Trait for configuring neural network layers in a Halo2 circuit.
 pub trait LayerConfig<F: FieldExt + TensorType> {
     /// Takes in VarTensor input and params, creates a series of operations (gates in Halo2 circuit nomenclature)
     /// using both input and params to produce an output to which we can add equality constraints (for proving).
     /// Produces a layer object with attributes we can then assign to when calling layout().
-    fn configure(
-        _meta: &mut ConstraintSystem<F>,
-        params: &[VarTensor],
-        input: VarTensor,
-        output: VarTensor,
-    ) -> Self;
-    /// Takes in ValTensor inputs and params and assigns them to the variables created when calling configure().
-    fn layout(
-        &self,
-        layouter: &mut impl Layouter<F>,
-        input: ValTensor<F>,
-        params: &[ValTensor<F>],
-    ) -> ValTensor<F>;
+    fn configure(_meta: &mut ConstraintSystem<F>, variables: &[VarTensor]) -> Self;
+    /// Takes in ValTensor inputs and assigns them to the variables created when calling configure().
+    fn layout(&self, layouter: &mut impl Layouter<F>, inputs: &[ValTensor<F>]) -> ValTensor<F>;
+}
+
+pub enum LayerType<
+    F: FieldExt + TensorType,
+    const STRIDE: usize,
+    const PADDING: usize,
+    const BITS: usize,
+    NL: eltwise::Nonlinearity<F>,
+> {
+    Conv(cnvrl::ConvConfig<F, STRIDE, PADDING>),
+    Affine(affine::Affine1dConfig<F>),
+    Eltwise(eltwise::EltwiseConfig<F, BITS, NL>),
 }

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -9,8 +9,8 @@ pub mod eltwise;
 
 /// Trait for configuring neural network layers in a Halo2 circuit.
 pub trait LayerConfig<F: FieldExt + TensorType> {
-    /// Takes in VarTensor input and params, creates a series of operations (gates in Halo2 circuit nomenclature)
-    /// using both input and params to produce an output to which we can add equality constraints (for proving).
+    /// Takes in VarTensors and creates a series of operations (gates in Halo2 circuit nomenclature)
+    /// to which we can add equality constraints (for proving).
     /// Produces a layer object with attributes we can then assign to when calling layout().
     fn configure(_meta: &mut ConstraintSystem<F>, variables: &[VarTensor]) -> Self;
     /// Takes in ValTensor inputs and assigns them to the variables created when calling configure().

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1,3 +1,5 @@
+/// Implementations of common operations on tensors.
+pub mod ops;
 /// A wrapper around a tensor of circuit variables / advices.
 pub mod val;
 /// A wrapper around a tensor of Halo2 Value types.
@@ -10,7 +12,7 @@ use crate::fieldutils::{felt_to_i32, i32_to_felt};
 
 use halo2_proofs::{
     arithmetic::FieldExt,
-    circuit::{AssignedCell, Value, Region},
+    circuit::{AssignedCell, Region, Value},
     plonk::{Advice, Assigned, Column, ConstraintSystem, Expression, Fixed, VirtualCells},
     poly::Rotation,
 };

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -138,7 +138,7 @@ pub fn dot_product<T: TensorType + Mul<Output = T> + Add<Output = T>>(
         .fold(T::zero().unwrap(), |acc, (k, i)| acc + k.clone() * i)
 }
 
-/// Pads a 3D tensor of shape `C x H x W` to a tensor of shape `C x (H + 2xPADDING) x (W + 2*PADDING)` using 0 values.
+/// Pads a 3D tensor of shape `C x H x W` to a tensor of shape `C x (H + 2xPADDING) x (W + 2xPADDING)` using 0 values.
 /// ```
 /// use halo2deeplearning::tensor::Tensor;
 /// use halo2deeplearning::tensor::ops::pad;

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -4,7 +4,7 @@ pub use std::ops::{Add, Mul};
 /// Matrix multiplies two 2D tensors.
 /// ```
 /// use halo2deeplearning::tensor::Tensor;
-/// use halo2deeplearning::tensor_ops::matmul;
+/// use halo2deeplearning::tensor::ops::matmul;
 ///
 /// let x = Tensor::<i32>::new(
 ///     Some(&[5, 2, 3, 0, 4, -1, 3, 1, 6]),
@@ -44,7 +44,7 @@ pub fn matmul<T: TensorType + Mul<Output = T> + Add<Output = T>>(
 /// Applies convolution over a 3D tensor of shape C x H x W.
 /// ```
 /// use halo2deeplearning::tensor::Tensor;
-/// use halo2deeplearning::tensor_ops::convolution;
+/// use halo2deeplearning::tensor::ops::convolution;
 ///
 /// let x = Tensor::<i32>::new(
 ///     Some(&[5, 2, 3, 0, 4, -1, 3, 1, 6]),
@@ -117,7 +117,7 @@ pub fn convolution<
 /// Dot product of two tensors.
 /// ```
 /// use halo2deeplearning::tensor::Tensor;
-/// use halo2deeplearning::tensor_ops::dot_product;
+/// use halo2deeplearning::tensor::ops::dot_product;
 ///
 /// let x = Tensor::<i32>::new(
 ///     Some(&[5, 2, 3, 0, 4, -1, 3, 1, 6]),
@@ -141,7 +141,7 @@ pub fn dot_product<T: TensorType + Mul<Output = T> + Add<Output = T>>(
 /// Pads a 3D tensor of shape `C x H x W` to a tensor of shape `C x (H + 2xPADDING) x (W + 2*PADDING)` using 0 values.
 /// ```
 /// use halo2deeplearning::tensor::Tensor;
-/// use halo2deeplearning::tensor_ops::pad;
+/// use halo2deeplearning::tensor::ops::pad;
 ///
 /// let x = Tensor::<i32>::new(
 ///     Some(&[5, 2, 3, 0, 4, -1, 3, 1, 6]),

--- a/src/tensor/val.rs
+++ b/src/tensor/val.rs
@@ -78,17 +78,20 @@ impl<F: FieldExt + TensorType> ValTensor<F> {
     /// Sets the `ValTensor`'s shape.
     pub fn reshape(&mut self, new_dims: &[usize]) {
         match self {
-            ValTensor::Value { inner: _, dims: d } => {
+            ValTensor::Value { inner: v, dims: d } => {
                 assert!(d.iter().product::<usize>() == new_dims.iter().product());
-                *d = new_dims.to_vec();
+                v.reshape(new_dims);
+                *d = v.dims().to_vec();
             }
-            ValTensor::AssignedValue { inner: _, dims: d } => {
+            ValTensor::AssignedValue { inner: v, dims: d } => {
                 assert!(d.iter().product::<usize>() == new_dims.iter().product());
-                *d = new_dims.to_vec();
+                v.reshape(new_dims);
+                *d = v.dims().to_vec();
             }
-            ValTensor::PrevAssigned { inner: _, dims: d } => {
+            ValTensor::PrevAssigned { inner: v, dims: d } => {
                 assert!(d.iter().product::<usize>() == new_dims.iter().product());
-                *d = new_dims.to_vec();
+                v.reshape(new_dims);
+                *d = v.dims().to_vec();
             }
         }
     }

--- a/src/tensor_ops/mod.rs
+++ b/src/tensor_ops/mod.rs
@@ -1,5 +1,3 @@
-/// Element-wise operations.
-pub mod eltwise;
 use crate::tensor::{Tensor, TensorType};
 pub use std::ops::{Add, Mul};
 


### PR DESCRIPTION
- Moves `eltwise` to the `nn` module
- Implements `LayerConfig` on `EltwiseConfig`
- Simplifies  `LayerConfig`
- Fixes issue whereby `ValTensor` inner wouldn't reshape
- Removes all constant traits on `ConvConfig` (fully dynamic)